### PR TITLE
Preserve invisibility status

### DIFF
--- a/R/memoise.r
+++ b/R/memoise.r
@@ -88,11 +88,16 @@ memoise <- memoize <- function(f) {
     hash <- digest(list(...))
     
     if (cache$has_key(hash)) {
-      cache$get(hash)
+      res <- cache$get(hash)
     } else {
-      res <- f(...)
+      res <- withVisible(f(...))
       cache$set(hash, res)
-      res
+    }
+
+    if (res$visible) {
+      res$value
+    } else {
+      invisible(res$value)
     }
   }
   attr(memo_f, "memoised") <- TRUE


### PR DESCRIPTION
The current version of memoise doesn't store the visibility status of the returned value, so even if a function returns `invisible()`, the value is printed:

```R
invis <- function() { invisible(10) }
invis()
# No output

m_invis <- memoise(invis)
m_invis()
# Prints 10 (not expected)

print(m_invis())
# Prints 10
```

This branch fixes it