### PR TITLE
memoise now warns if the input function has already been memoised

### DIFF
--- a/R/memoise.r
+++ b/R/memoise.r
@@ -82,6 +82,10 @@
 #' memA <- memoise(a)
 #' memA(2)
 memoise <- memoize <- function(f) {
+  if(is.memoised(f))
+  {
+    warning(deparse(substitute(f)), " is already memoised.")
+  }
   cache <- new_cache()
   
   memo_f <- function(...) {


### PR DESCRIPTION
The help documentation cautions about calling memoise on functions that have already been memoised, since it will reset the cache.  It seems sensible to have a warning built-in to the function to notify the user when they are doing this.