### PR TITLE
Allow invalidating cache with non-arguments.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,4 +12,4 @@ Imports:
 Suggests:
     testthat
 License: MIT + file LICENSE
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -187,13 +187,14 @@ memoise_old <- function(f, ...) {
 }
 
 validate_formulas <- function(...) {
+  format.name <- function(x, ...) format(as.character(x), ...)
   is_formula <- function(x) {
     if (is.call(x) && identical(x[[1]], as.name("~"))) {
       if (length(x) > 2L) {
         stop("`x` must be a one sided formula [not ", format(x), "].", call. = FALSE)
       }
     } else {
-      stop("`x` must be a formula.", call. = FALSE)
+      stop("`", format(x), "` must be a formula.", call. = FALSE)
     }
   }
 

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -123,7 +123,7 @@ memoise_new <- function(f, ..., envir) {
 
   memo_f <- eval(
     bquote(function(...) {
-      hash <- digest(c(.(list_call), lapply(additional, evaluate_formula)))
+      hash <- digest(c(.(list_call), lapply(additional, function(x) eval(x[[2L]], environment(x)))))
 
       if (cache$has_key(hash)) {
         res <- cache$get(hash)
@@ -167,7 +167,7 @@ memoise_old <- function(f, ...) {
   additional <- list(...)
 
   memo_f <- function(...) {
-    hash <- digest(c(list(...), lapply(additional, evaluate_formula)))
+    hash <- digest(c(list(...), lapply(additional, function(x) eval(x[[2L]], environment(x)))))
 
     if (cache$has_key(hash)) {
       res <- cache$get(hash)
@@ -190,25 +190,15 @@ validate_formulas <- function(...) {
   is_formula <- function(x) {
     if (is.call(x) && identical(x[[1]], as.name("~"))) {
       if (length(x) > 2L) {
-        stop("Formulas with a LHS cannot be evaluated", call. = FALSE)
+        stop("`x` must be a one sided formula [not ", format(x), "].", call. = FALSE)
       }
     } else {
-      stop("Input must be a formula", call. = FALSE)
+      stop("`x` must be a formula.", call. = FALSE)
     }
   }
 
   dots <- eval(substitute(alist(...)))
   lapply(dots, is_formula)
-}
-
-evaluate_formula <- function(x) {
-  if (!inherits(x, "formula")) {
-    stop("Must evaluate a formula", call. = FALSE)
-  }
-  if (length(x) > 2) {
-    stop("formulas with a LHS cannot be evaluated", call. = FALSE)
-  }
-  eval(x[[2]], environment(x))
 }
 
 #' @export

--- a/man/is.memoised.Rd
+++ b/man/is.memoised.Rd
@@ -4,7 +4,7 @@
 \alias{is.memoised}
 \alias{is.memoized}
 \title{Test whether a function is a memoised copy.
-Memoised copies of functions carry an attribute 
+Memoised copies of functions carry an attribute
 \code{memoised = TRUE}, which is.memoised() tests for.}
 \usage{
 is.memoised(f)
@@ -14,7 +14,7 @@ is.memoised(f)
 }
 \description{
 Test whether a function is a memoised copy.
-Memoised copies of functions carry an attribute 
+Memoised copies of functions carry an attribute
 \code{memoised = TRUE}, which is.memoised() tests for.
 }
 \examples{

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -5,10 +5,13 @@
 \alias{memoize}
 \title{Memoise a function.}
 \usage{
-memoise(f, envir = parent.frame())
+memoise(f, ..., envir = parent.frame())
 }
 \arguments{
 \item{f}{Function of which to create a memoised copy.}
+
+\item{...}{optional variables specified as formulas with no RHS to use as
+additional restrictions on caching. See Examples for usage.}
 
 \item{envir}{Environment of the returned function.}
 }
@@ -21,8 +24,8 @@ circumstances, this can provide a very nice speedup indeed.
 }
 \details{
 There are two main ways to use the \code{memoise} function. Say that
-you wish to memoise \code{glm}, which is in the \code{stats} 
-package; then you could use \cr 
+you wish to memoise \code{glm}, which is in the \code{stats}
+package; then you could use \cr
   \code{  mem_glm <- memoise(glm)}, or you could use\cr
   \code{  glm <- memoise(stats::glm)}. \cr
 The first form has the advantage that you still have easy access to
@@ -38,7 +41,7 @@ Two example situations where \code{memoise} could be of use:
   \item You're debugging or developing something, which involves
     a lot of re-running the code.  If there are a few expensive calls
     in there, memoising them can make life a lot more pleasant.
-    If the code is in a script file that you're \code{source()}ing, 
+    If the code is in a script file that you're \code{source()}ing,
     take care that you don't just put \cr
       \code{  glm <- memoise(stats::glm)} \cr
     at the top of your file: that would reinitialise the memoised
@@ -49,7 +52,7 @@ Two example situations where \code{memoise} could be of use:
 }
 }
 \examples{
-# a() is evaluated anew each time. memA() is only re-evaluated 
+# a() is evaluated anew each time. memA() is only re-evaluated
 # when you call it with a new set of parameters.
 a <- function(n) { runif(n) }
 memA <- memoise(a)
@@ -60,7 +63,7 @@ replicate(5, memA(2))
 # changed-value correctly produces two different outcomes...
 N <- 4; memA(N)
 N <- 5; memA(N)
-# ... and same-value-but-different-name correctly produces 
+# ... and same-value-but-different-name correctly produces
 #     the same cached outcome.
 N <- 4; memA(N)
 N2 <- 4; memA(N2)
@@ -79,24 +82,27 @@ formals(memB)
 # that the outcome is the same.
 memB(2, dummy="b")
 
-# You can create multiple memoisations of the same function, 
-# and they'll be independent. 
+# You can create multiple memoisations of the same function,
+# and they'll be independent.
 memA(2)
 memA2 <- memoise(a)
 memA(2)  # Still the same outcome
 memA2(2) # Different cache, different outcome
 
-# Don't do the same memoisation assignment twice: a brand-new 
-# memoised function also means a brand-new cache, and *that* 
+# Don't do the same memoisation assignment twice: a brand-new
+# memoised function also means a brand-new cache, and *that*
 # you could as easily and more legibly achieve using forget().
-# (If you're not sure whether you already memoised something,  
+# (If you're not sure whether you already memoised something,
 #  use is.memoised() to check.)
 memA(2)
 memA <- memoise(a)
 memA(2)
+# Making a memoized automatically time out after 10 seconds.
+memA3 <- memoise(a, ~{current <- as.numeric(Sys.time()); (current - current \%\% 10) \%/\% 10 })
+memA3(2)
 }
 \seealso{
-\code{\link{forget}}, \code{\link{is.memoised}}, 
+\code{\link{forget}}, \code{\link{is.memoised}},
     \url{http://en.wikipedia.org/wiki/Memoization}
 }
 

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -181,10 +181,17 @@ test_that("printing a memoised function prints the original definition", {
 })
 
 test_that("memoisation can depend on non-arguments", {
-  fn <- function(j) { i <<- i + 1; i }
+  fn <- function(x) { i <<- i + 1; i }
   i <- 0
   j <- 2
-  fnm <- memoise(fn, j)
+
+  expect_error(memoise(fn, j), "Input must be a formula")
+
+  expect_error(memoise(fn, ~j, k), "Input must be a formula")
+
+  expect_error(memoise(fn, j ~ 1), "Formulas with a LHS cannot be evaluated")
+
+  fnm <- memoise(fn, ~j)
   expect_equal(fn(1), 1)
   expect_equal(fn(1), 2)
   expect_equal(fnm(1), 3)
@@ -193,6 +200,9 @@ test_that("memoisation can depend on non-arguments", {
   expect_equal(fnm(1), 4)
   expect_equal(fnm(1), 4)
   j <- 2
+  expect_equal(fnm(1), 3)
+  expect_equal(fnm(1), 3)
+  j <- 3
   expect_equal(fnm(1), 5)
   expect_equal(fnm(1), 5)
 })

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -185,11 +185,11 @@ test_that("memoisation can depend on non-arguments", {
   i <- 0
   j <- 2
 
-  expect_error(memoise(fn, j), "Input must be a formula")
+  expect_error(memoise(fn, j), "`x` must be a formula\\.")
 
-  expect_error(memoise(fn, ~j, k), "Input must be a formula")
+  expect_error(memoise(fn, ~j, k), "`x` must be a formula\\.")
 
-  expect_error(memoise(fn, j ~ 1), "Formulas with a LHS cannot be evaluated")
+  expect_error(memoise(fn, j ~ 1), "`x` must be a one sided formula \\[not j ~ 1\\]\\.")
 
   fnm <- memoise(fn, ~j)
   expect_equal(fn(1), 1)

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -185,6 +185,10 @@ test_that("memoisation can depend on non-arguments", {
   i <- 0
   j <- 2
 
+  fn2 <- function(y, ...) {
+    fnm <- memoise(fn, ~y)
+    fnm(...)
+  }
   expect_error(memoise(fn, j), "`j` must be a formula\\.")
 
   expect_error(memoise(fn, ~j, k), "`k` must be a formula\\.")

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -185,9 +185,9 @@ test_that("memoisation can depend on non-arguments", {
   i <- 0
   j <- 2
 
-  expect_error(memoise(fn, j), "`x` must be a formula\\.")
+  expect_error(memoise(fn, j), "`j` must be a formula\\.")
 
-  expect_error(memoise(fn, ~j, k), "`x` must be a formula\\.")
+  expect_error(memoise(fn, ~j, k), "`k` must be a formula\\.")
 
   expect_error(memoise(fn, j ~ 1), "`x` must be a one sided formula \\[not j ~ 1\\]\\.")
 

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -173,11 +173,26 @@ test_that("printing a memoised function prints the original definition", {
   fnm <- memoise(fn)
 
   fn_output <- capture.output(fn)
-  str(fn_output)
   fnm_output <- capture.output(fnm)
-  str(fnm_output)
 
   expect_equal(fnm_output[1], "Memoised Function:")
 
   expect_equal(fnm_output[-1], fn_output)
+})
+
+test_that("memoisation can depend on non-arguments", {
+  fn <- function(j) { i <<- i + 1; i }
+  i <- 0
+  j <- 2
+  fnm <- memoise(fn, j)
+  expect_equal(fn(1), 1)
+  expect_equal(fn(1), 2)
+  expect_equal(fnm(1), 3)
+  expect_equal(fnm(1), 3)
+  j <- 1
+  expect_equal(fnm(1), 4)
+  expect_equal(fnm(1), 4)
+  j <- 2
+  expect_equal(fnm(1), 5)
+  expect_equal(fnm(1), 5)
 })


### PR DESCRIPTION
This lets you depend on things like `search()`, system environment variables, `options()` ect without having to make them a function argument.